### PR TITLE
WIP - AWS ECS w/ launch_type=EC2

### DIFF
--- a/modules/aws_ecs/ecs.tf
+++ b/modules/aws_ecs/ecs.tf
@@ -37,27 +37,29 @@ data "aws_ami" "this" {
   ]
 }
 
-resource "aws_launch_configuration" "this" {
+resource "aws_launch_template" "this" {
   count         = var.launch_type == "EC2" ? 1 : 0
-  name_prefix   = "${var.deployment_name}-ecs-launch-configuration-"
+  name_prefix   = "${var.deployment_name}-ecs-launch-template-"
   image_id      = data.aws_ami.this.id
   instance_type = var.instance_type # e.g. t2.medium
 
-  enable_monitoring           = true
-  associate_public_ip_address = true
+  monitoring {
+    enabled = true
+  }
+
+  network_interfaces {
+    associate_public_ip_address = true
+    security_groups             = [aws_security_group.containers.id]
+  }
 
   # This user data represents a collection of “scripts” that will be executed the first time the machine starts.
   # This specific example makes sure the EC2 instance is automatically attached to the ECS cluster that we create earlier
   # and marks the instance as purchased through the Spot pricing
-  user_data = <<-EOF
-  #!/bin/bash
-  echo ECS_CLUSTER=${var.deployment_name}-ecs >> /etc/ecs/ecs.config
+  user_data = base64encode(<<-EOF
+    #!/bin/bash
+    echo ECS_CLUSTER=${var.deployment_name}-ecs >> /etc/ecs/ecs.config
   EOF
-
-  # We’ll see security groups later
-  security_groups = [
-    aws_security_group.containers.id
-  ]
+  )
 
   # If you want to SSH into the instance and manage it directly:
   # 1. Make sure this key exists in the AWS EC2 dashboard
@@ -66,7 +68,9 @@ resource "aws_launch_configuration" "this" {
   key_name = var.ssh_key_name
 
   # Allow the EC2 instances to access AWS resources on your behalf, using this instance profile and the permissions defined there
-  iam_instance_profile = aws_iam_instance_profile.ec2[0].arn
+  iam_instance_profile {
+    name = aws_iam_instance_profile.ec2[0].name
+  }
 
   lifecycle {
     create_before_destroy = true
@@ -74,16 +78,21 @@ resource "aws_launch_configuration" "this" {
 }
 
 resource "aws_autoscaling_group" "this" {
-  count                = var.launch_type == "EC2" ? 1 : 0
-  name                 = "${var.deployment_name}-autoscaling-group"
-  max_size             = var.max_instance_count
-  min_size             = var.min_instance_count
-  desired_capacity     = var.min_instance_count
-  vpc_zone_identifier  = var.private_subnet_ids
-  launch_configuration = aws_launch_configuration.this[0].name
+  count               = var.launch_type == "EC2" ? 1 : 0
+  name                = "${var.deployment_name}-autoscaling-group"
+  max_size            = var.max_instance_count
+  min_size            = var.min_instance_count
+  desired_capacity    = var.min_instance_count
+  vpc_zone_identifier = var.private_subnet_ids
+
+  launch_template {
+    id      = aws_launch_template.this[0].id
+    version = "$Latest"
+  }
 
   default_cooldown          = 30
   health_check_grace_period = 30
+  health_check_type         = "EC2"
 
   termination_policies = [
     "OldestInstance"

--- a/modules/aws_ecs/ecs.tf
+++ b/modules/aws_ecs/ecs.tf
@@ -48,7 +48,7 @@ resource "aws_launch_template" "this" {
   }
 
   network_interfaces {
-    associate_public_ip_address = true
+    associate_public_ip_address = false
     security_groups             = [aws_security_group.containers.id]
   }
 

--- a/modules/aws_ecs/loadbalancers.tf
+++ b/modules/aws_ecs/loadbalancers.tf
@@ -58,7 +58,7 @@ resource "aws_lb_target_group" "this" {
   deregistration_delay = 30
   port                 = 3000
   protocol             = "HTTP"
-  target_type          = var.launch_type == "FARGATE" ? "ip" : "instance"
+  target_type          = var.launch_type == "FARGATE" ? "ip" : "ip"
 
   health_check {
     interval            = 61

--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -54,7 +54,7 @@ resource "aws_ecs_service" "retool" {
   desired_count                      = var.min_instance_count - 1
   deployment_maximum_percent         = var.maximum_percent
   deployment_minimum_healthy_percent = var.minimum_healthy_percent
-  iam_role                           = var.launch_type == "EC2" ? aws_iam_role.service_role.arn : null
+  # iam_role                           = var.launch_type == "EC2" ? aws_iam_role.service_role.arn : null
   propagate_tags                     = var.task_propagate_tags
   enable_execute_command             = var.enable_execute_command
 
@@ -71,16 +71,10 @@ resource "aws_ecs_service" "retool" {
     capacity_provider = var.launch_type == "FARGATE" ? "FARGATE" : aws_ecs_capacity_provider.this[0].name
   }
 
-  dynamic "network_configuration" {
-    for_each = var.launch_type == "FARGATE" ? toset([1]) : toset([])
-
-    content {
-      subnets = var.private_subnet_ids
-      security_groups = [
-        aws_security_group.containers.id
-      ]
-      assign_public_ip = true
-    }
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [aws_security_group.containers.id]
+    assign_public_ip = var.launch_type == "FARGATE" ? true : false
   }
 }
 
@@ -99,16 +93,10 @@ resource "aws_ecs_service" "jobs_runner" {
     capacity_provider = var.launch_type == "FARGATE" ? "FARGATE" : aws_ecs_capacity_provider.this[0].name
   }
 
-  dynamic "network_configuration" {
-    for_each = var.launch_type == "FARGATE" ? toset([1]) : toset([])
-
-    content {
-      subnets = var.private_subnet_ids
-      security_groups = [
-        aws_security_group.containers.id
-      ]
-      assign_public_ip = true
-    }
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [aws_security_group.containers.id]
+    assign_public_ip = var.launch_type == "FARGATE" ? true : false
   }
 }
 
@@ -132,16 +120,10 @@ resource "aws_ecs_service" "workflows_backend" {
     registry_arn = aws_service_discovery_service.retool_workflow_backend_service[0].arn
   }
 
-  dynamic "network_configuration" {
-    for_each = var.launch_type == "FARGATE" ? toset([1]) : toset([])
-
-    content {
-      subnets = var.private_subnet_ids
-      security_groups = [
-        aws_security_group.containers.id
-      ]
-      assign_public_ip = true
-    }
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [aws_security_group.containers.id]
+    assign_public_ip = var.launch_type == "FARGATE" ? true : false
   }
 }
 
@@ -161,16 +143,10 @@ resource "aws_ecs_service" "workflows_worker" {
     capacity_provider = var.launch_type == "FARGATE" ? "FARGATE" : aws_ecs_capacity_provider.this[0].name
   }
 
-  dynamic "network_configuration" {
-    for_each = var.launch_type == "FARGATE" ? toset([1]) : toset([])
-
-    content {
-      subnets = var.private_subnet_ids
-      security_groups = [
-        aws_security_group.containers.id
-      ]
-      assign_public_ip = true
-    }
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [aws_security_group.containers.id]
+    assign_public_ip = var.launch_type == "FARGATE" ? true : false
   }
 }
 
@@ -193,16 +169,10 @@ resource "aws_ecs_service" "code_executor" {
     registry_arn = aws_service_discovery_service.retool_code_executor_service[0].arn
   }
 
-  dynamic "network_configuration" {
-    for_each = var.launch_type == "FARGATE" ? toset([1]) : toset([])
-
-    content {
-      subnets = var.private_subnet_ids
-      security_groups = [
-        aws_security_group.containers.id
-      ]
-      assign_public_ip = true
-    }
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [aws_security_group.containers.id]
+    assign_public_ip = var.launch_type == "FARGATE" ? true : false
   }
 }
 
@@ -226,16 +196,10 @@ resource "aws_ecs_service" "telemetry" {
     registry_arn = aws_service_discovery_service.retool_telemetry_service[0].arn
   }
 
-  dynamic "network_configuration" {
-    for_each = var.launch_type == "FARGATE" ? toset([1]) : toset([])
-
-    content {
-      subnets = var.private_subnet_ids
-      security_groups = [
-        aws_security_group.containers.id
-      ]
-      assign_public_ip = true
-    }
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [aws_security_group.containers.id]
+    assign_public_ip = var.launch_type == "FARGATE" ? true : false
   }
 }
 
@@ -243,8 +207,8 @@ resource "aws_ecs_task_definition" "retool_jobs_runner" {
   family                   = "retool-jobs-runner"
   task_role_arn            = aws_iam_role.task_role.arn
   execution_role_arn       = var.launch_type == "FARGATE" ? aws_iam_role.execution_role[0].arn : null
-  requires_compatibilities = var.launch_type == "FARGATE" ? ["FARGATE"] : null
-  network_mode             = var.launch_type == "FARGATE" ? "awsvpc" : "bridge"
+  requires_compatibilities = var.launch_type == "FARGATE" ? ["FARGATE"] : ["EC2"]
+  network_mode             = var.launch_type == "FARGATE" ? "awsvpc" : "awsvpc"
   cpu                      = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["jobs_runner"]["cpu"] : null
   memory                   = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["jobs_runner"]["memory"] : null
   container_definitions = jsonencode(concat(
@@ -288,8 +252,8 @@ resource "aws_ecs_task_definition" "retool" {
   family                   = "retool"
   task_role_arn            = aws_iam_role.task_role.arn
   execution_role_arn       = var.launch_type == "FARGATE" ? aws_iam_role.execution_role[0].arn : null
-  requires_compatibilities = var.launch_type == "FARGATE" ? ["FARGATE"] : null
-  network_mode             = var.launch_type == "FARGATE" ? "awsvpc" : "bridge"
+  requires_compatibilities = var.launch_type == "FARGATE" ? ["FARGATE"] : ["EC2"]
+  network_mode             = var.launch_type == "FARGATE" ? "awsvpc" : "awsvpc"
   cpu                      = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["main"]["cpu"] : null
   memory                   = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["main"]["memory"] : null
 
@@ -339,8 +303,8 @@ resource "aws_ecs_task_definition" "retool_workflows_backend" {
   family                   = "retool-workflows-backend"
   task_role_arn            = aws_iam_role.task_role.arn
   execution_role_arn       = var.launch_type == "FARGATE" ? aws_iam_role.execution_role[0].arn : null
-  requires_compatibilities = var.launch_type == "FARGATE" ? ["FARGATE"] : null
-  network_mode             = var.launch_type == "FARGATE" ? "awsvpc" : "bridge"
+  requires_compatibilities = var.launch_type == "FARGATE" ? ["FARGATE"] : ["EC2"]
+  network_mode             = var.launch_type == "FARGATE" ? "awsvpc" : "awsvpc"
   cpu                      = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["workflows_backend"]["cpu"] : null
   memory                   = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["workflows_backend"]["memory"] : null
 
@@ -390,8 +354,8 @@ resource "aws_ecs_task_definition" "retool_workflows_worker" {
   family                   = "retool-workflows-worker"
   task_role_arn            = aws_iam_role.task_role.arn
   execution_role_arn       = var.launch_type == "FARGATE" ? aws_iam_role.execution_role[0].arn : null
-  requires_compatibilities = var.launch_type == "FARGATE" ? ["FARGATE"] : null
-  network_mode             = var.launch_type == "FARGATE" ? "awsvpc" : "bridge"
+  requires_compatibilities = var.launch_type == "FARGATE" ? ["FARGATE"] : ["EC2"]
+  network_mode             = var.launch_type == "FARGATE" ? "awsvpc" : "awsvpc"
   cpu                      = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["workflows_worker"]["cpu"] : null
   memory                   = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["workflows_worker"]["memory"] : null
 
@@ -445,8 +409,8 @@ resource "aws_ecs_task_definition" "retool_code_executor" {
   family                   = "retool-code-executor"
   task_role_arn            = aws_iam_role.task_role.arn
   execution_role_arn       = var.launch_type == "FARGATE" ? aws_iam_role.execution_role[0].arn : null
-  requires_compatibilities = var.launch_type == "FARGATE" ? ["FARGATE"] : null
-  network_mode             = var.launch_type == "FARGATE" ? "awsvpc" : "bridge"
+  requires_compatibilities = var.launch_type == "FARGATE" ? ["FARGATE"] : ["EC2"]
+  network_mode             = var.launch_type == "FARGATE" ? "awsvpc" : "awsvpc"
   cpu                      = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["code_executor"]["cpu"] : null
   memory                   = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["code_executor"]["memory"] : null
 
@@ -498,8 +462,8 @@ resource "aws_ecs_task_definition" "retool_telemetry" {
   family                   = "retool-telemetry"
   task_role_arn            = aws_iam_role.task_role.arn
   execution_role_arn       = var.launch_type == "FARGATE" ? aws_iam_role.execution_role[0].arn : null
-  requires_compatibilities = var.launch_type == "FARGATE" ? ["FARGATE"] : null
-  network_mode             = var.launch_type == "FARGATE" ? "awsvpc" : "bridge"
+  requires_compatibilities = var.launch_type == "FARGATE" ? ["FARGATE"] : ["EC2"]
+  network_mode             = var.launch_type == "FARGATE" ? "awsvpc" : "awsvpc"
   cpu                      = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["telemetry"]["cpu"] : null
   memory                   = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["telemetry"]["memory"] : null
 

--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -450,7 +450,12 @@ resource "aws_ecs_task_definition" "retool_code_executor" {
               name  = "CONTAINER_UNPRIVILEGED_MODE"
               value = "true"
             }
-          ] : []
+          ] : [
+            {
+            name  = "DISABLE_IPTABLES_SECURITY_CONFIGURATION"
+            value = "true"
+            }
+          ]
         )
       }
     ]

--- a/modules/aws_ecs/roles.tf
+++ b/modules/aws_ecs/roles.tf
@@ -127,6 +127,7 @@ data "aws_iam_policy_document" "ec2_policy" {
   statement {
     actions = [
       "ec2:DescribeTags",
+      "ec2:DescribeInstances",
       "ecs:CreateCluster",
       "ecs:DeregisterContainerInstance",
       "ecs:DiscoverPollEndpoint",
@@ -140,7 +141,12 @@ data "aws_iam_policy_document" "ec2_policy" {
       "ecr:GetDownloadUrlForLayer",
       "ecr:BatchGetImage",
       "logs:CreateLogStream",
-      "logs:PutLogEvents"
+      "logs:PutLogEvents",
+      "ec2:CreateNetworkInterface",
+      "ec2:DeleteNetworkInterface",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:AttachNetworkInterface",
+      "ec2:DetachNetworkInterface"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
This PR includes several changes so far, with the goal of being able to run with `launch_type=EC2` and being able to use Python custom libraries ([Retool docs](https://docs.retool.com/workflows/guides/blocks/python#add-custom-libraries))

- [ ] move from deprecated `aws_launch_configuration` to `aws_launch_template` ([AWS docs on deprecation](https://docs.aws.amazon.com/autoscaling/ec2/userguide/migrate-to-launch-templates.html)) ([5fad9e3](https://github.com/marks/terraform-retool-modules/pull/1/commits/5fad9e326eab6f918268a5a439e83a2b8ec7faa1))
- [ ] move from `network_mode=bridge` to `network_mode=awsvpc` for `launch_type=EC2` to be consistent with [Cloudformation example](https://github.com/tryretool/retool-onpremise/blob/master/cloudformation/retool-workflows.ec2.yaml) (and because I was having issues with bridge mode ([72d2483](https://github.com/marks/terraform-retool-modules/pull/1/commits/72d248389bda70be471db5b93ba6e500bfa2f2e6))
- [ ] set DISABLE_IPTABLES_SECURITY_CONFIGURATION to true (hopefully temporarily) to get CE to start ([437947c])(https://github.com/marks/terraform-retool-modules/pull/1/commits/437947cf57234209fdaa86fe5d3766590a57e44f)
- [ ] move to Ubuntu 22 from Amazon Linux to try to get CE to work with nsjail (not yet working) ([fdb7270](https://github.com/marks/terraform-retool-modules/pull/1/commits/fdb72705f8cfc5283e576a2743f2692711b09feb))


Current status
- deploy was working with first two commits but w/o code executor having access to nsjail

Notes:
- :warning: have only been testing with `launch_type=EC2` and Retool-managed Temporal so far